### PR TITLE
Decouple datasets configurations into sub-configurations

### DIFF
--- a/conf/nn/data/coildel.yaml
+++ b/conf/nn/data/coildel.yaml
@@ -1,0 +1,19 @@
+dataset_name: COIL-DEL
+
+train_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 15
+  num_classes_per_episode: 5
+  num_supports_per_class: 10
+
+val_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 15
+  num_classes_per_episode: 5
+  num_supports_per_class: 10
+
+test_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 15
+  num_classes_per_episode: 5
+  num_supports_per_class: 10

--- a/conf/nn/data/enzymes.yaml
+++ b/conf/nn/data/enzymes.yaml
@@ -1,0 +1,19 @@
+dataset_name: ENZYMES
+
+train_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 15
+  num_classes_per_episode: 4
+  num_supports_per_class: 10
+
+val_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 5
+  num_classes_per_episode: 4
+  num_supports_per_class: 5
+
+test_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 15
+  num_classes_per_episode: 2
+  num_supports_per_class: 10

--- a/conf/nn/data/letterhigh.yaml
+++ b/conf/nn/data/letterhigh.yaml
@@ -1,0 +1,19 @@
+dataset_name: Letter_high
+
+train_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 15
+  num_classes_per_episode: 4
+  num_supports_per_class: 10
+
+val_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 5
+  num_classes_per_episode: 4
+  num_supports_per_class: 5
+
+test_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 15
+  num_classes_per_episode: 4
+  num_supports_per_class: 10

--- a/conf/nn/data/r52.yaml
+++ b/conf/nn/data/r52.yaml
@@ -1,0 +1,19 @@
+dataset_name: R52
+
+train_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 13
+  num_classes_per_episode: 4
+  num_supports_per_class: 10
+
+val_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 13
+  num_classes_per_episode: 4
+  num_supports_per_class: 10
+
+test_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 15
+  num_classes_per_episode: 2
+  num_supports_per_class: 10

--- a/conf/nn/data/reddit.yaml
+++ b/conf/nn/data/reddit.yaml
@@ -1,0 +1,19 @@
+dataset_name: Reddit
+
+train_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 15
+  num_classes_per_episode: 4
+  num_supports_per_class: 10
+
+val_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 5
+  num_classes_per_episode: 4
+  num_supports_per_class: 5
+
+test_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 15
+  num_classes_per_episode: 4
+  num_supports_per_class: 10

--- a/conf/nn/data/triangles.yaml
+++ b/conf/nn/data/triangles.yaml
@@ -1,0 +1,19 @@
+dataset_name: TRIANGLES
+
+train_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 15
+  num_classes_per_episode: 3
+  num_supports_per_class: 10
+
+val_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 5
+  num_classes_per_episode: 3
+  num_supports_per_class: 5
+
+test_episode_hparams:
+  _target_: fs_grl.data.episode.EpisodeHParams
+  num_queries_per_class: 15
+  num_classes_per_episode: 3
+  num_supports_per_class: 10

--- a/conf/nn/default.yaml
+++ b/conf/nn/default.yaml
@@ -9,12 +9,14 @@
 #   - NEVER use both on TRIANGLES, as tags are the same as degree, other datasets must still be tried
 
 defaults:
-  - model/gnn_embedding_cosine
+  - _self_
+  - model: gnn_embedding_cosine
+  - data: triangles
 
 data:
   _target_: fs_grl.data.datamodule.GraphMetaDataModule
 
-  dataset_name: R52 # TRIANGLES, Letter_high, ENZYMES, Reddit
+  dataset_name: ???
   feature_params:
     features_to_consider:
       - degree


### PR DESCRIPTION
It is now possible to perform a sweep over datasets with:
```bash
python src/fs_grl/run_dml.py -m nn/data=coildel,enzymes,letterhigh,r52,reddit,triangles
```