### PR TITLE
Add 'ADDVAR' pooling method in the Embedder

### DIFF
--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -3,7 +3,8 @@ core:
   project_name: fs-grl
   storage_dir: ${oc.env:PROJECT_ROOT}/storage
   version: 0.0.1
-  tags: develop
+  tags:
+    - addvar
 
 defaults:
   - hydra: default

--- a/conf/nn/default.yaml
+++ b/conf/nn/default.yaml
@@ -20,9 +20,9 @@ data:
   feature_params:
     features_to_consider:
       - degree
-      - num_cycles
-    max_considered_cycle_len: 3
-
+        #      - num_cycles
+    max_considered_cycle_len: 4
+    
   data_dir: ${oc.env:PROJECT_ROOT}/data/${nn.data.dataset_name}
   classes_split_path: ${nn.data.data_dir}/classes_split.json
   prototypes_path: ${nn.data.data_dir}/prototypes.pt
@@ -59,9 +59,9 @@ data:
   gpus: ${train.trainer.gpus}
 
   num_workers:
-    train: 8
-    val: 4
-    test: 4
+    train: 0
+    val: 0
+    test: 0
 
   batch_size:
     train: 16

--- a/conf/nn/model/gnn_embedding_cosine.yaml
+++ b/conf/nn/model/gnn_embedding_cosine.yaml
@@ -14,9 +14,9 @@ model:
     _target_: fs_grl.modules.gnn_embedder.GNNEmbedder
     feature_dim: ???
     num_mlp_layers: 2
-    embedding_dim: 32
+    embedding_dim: 64
     hidden_dim: 32
     num_convs: 2
     dropout_rate: 0.5
-    pooling: sum # sum, GMT
+    pooling: ADDVAR # sum, GMT, ADDVAR
     do_preprocess: false

--- a/conf/train/default.yaml
+++ b/conf/train/default.yaml
@@ -94,6 +94,7 @@ logging:
     entity: gladia
     log_model: ${..upload.run_files}
     mode: 'online'
+    tags: ${core.tags}
 
 meta-testing-logging:
   upload:

--- a/src/fs_grl/run_dml.py
+++ b/src/fs_grl/run_dml.py
@@ -68,8 +68,12 @@ def run(cfg: DictConfig) -> str:
     pylogger.info("Starting training!")
     trainer.fit(model=model, datamodule=datamodule)
 
-    pylogger.info("Starting testing!")
-    trainer.test(datamodule=datamodule)
+    if fast_dev_run:
+        pylogger.info("Skipping testing in 'fast_dev_run' mode!")
+    else:
+        if trainer.checkpoint_callback.best_model_path is not None:
+            pylogger.info("Starting testing!")
+            trainer.test(datamodule=datamodule)
 
     if logger is not None:
         logger.experiment.finish()


### PR DESCRIPTION
Add the `ADDVAR` pooling method for the Embedder. The behavior is implemented in the `GlobalAddVarPool` class. 
This pooling method considers both the sum and the std of the node embeddings when aggregating the features.

The output embedding dimension is the same:
- half of the embedding represents the sum in each dimension
- the other half the std. 


Before the aggregation, a linear projection halves the dimension of the features.

---

Moreover:
- Fixes missing wandb tags (updated from template 2.0.1)
- Fixes testing in fast dev run (updated from template 2.0.1)

If necessary, I can split those fixes into another PR.